### PR TITLE
Proxy Support

### DIFF
--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -4686,6 +4686,18 @@ public interface DataDictionaryInterface
                 fail since the cache is not available and this setting is False.
                 </blockquote>
           </li>
+          <li><blockquote><b>use_battlelog_proxy</b><br />
+                <i>True</i> - Send requests to web services over a proxy.<br />
+                <i>False</i> - Do not use a proxy.<br />
+                <br />
+                </blockquote>
+          </li>
+          <li><blockquote><b>proxy_url</b><br />
+                <i>(string, url)</i> - Format: http://IP:PORT - http://user:password@IP:PORT<br />
+                <br />
+                The URL of the proxy server.
+                </blockquote>
+          </li>
           <li><blockquote><b>use_slow_weapon_stats</b><br />
                 <i>False</i> - skip fetching weapon stats for new players<br />
                 <i>True</i> - fetch weapon stats for new players<br />

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -3764,7 +3764,7 @@ namespace PRoConEvents
 
         public string GetPluginVersion()
         {
-            return "0.9.18.0";
+            return "0.9.18.1";
         }
 
         public string GetPluginAuthor()

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13682,11 +13682,15 @@ public interface DataDictionaryInterface
         public class GZipWebClient : WebClient {
             private String ua;
             private bool compress;
-
-            public GZipWebClient(String ua = "Mozilla/5.0 (compatible; PRoCon 1; Insane Limits)", bool compress = true) {
-                this.ua = ua;
-                this.compress = compress;
+            
+            public GZipWebClient() {
+                this.ua = "Mozilla/5.0 (compatible; PRoCon 1; Insane Limits)";
                 base.Headers["User-Agent"] = ua;
+                compress = true;
+            }
+
+            public GZipWebClient(bool compress) : this() {
+                this.compress = compress;
             }
 
             public string GZipDownloadString(string address) {

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13761,7 +13761,7 @@ public interface DataDictionaryInterface
                     // set proxy
                     try {
                         var address = plugin.getStringVarValue("proxy_url");
-                        if (!curAddress.Equals(address)) {
+                        if (curAddress == null || !curAddress.Equals(address)) {
                             client.SetProxy(address); 
                             curAddress = address;
                         }

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13701,10 +13701,15 @@ public interface DataDictionaryInterface
                 // proxy support
                 if (plugin.getBooleanVarValue("use_battlelog_proxy")) {
                     // set proxy
-                    var address = plugin.getStringVarValue("proxy_url");
-                    if (proxy == null || !curAddress.Equals(address)) {
-                        proxy = new WebProxy(address, true);
-                        curAddress = address;
+                    try {
+                        var address = plugin.getStringVarValue("proxy_url");
+                        if (proxy == null || !curAddress.Equals(address)) {
+                            proxy = new WebProxy(address, true);
+                            curAddress = address;
+                        }
+                    }
+                    catch (UriFormatException) {
+                        plugin.ConsoleError("Invalid Proxy URL set!");
                     }
                 }
                 else {

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13706,12 +13706,21 @@ public interface DataDictionaryInterface
                 
                 var contentEncoding = ResponseHeaders[HttpResponseHeader.ContentEncoding];
                 base.Headers.Remove(HttpRequestHeader.AcceptEncoding);
-                
+
+                Stream decompressedStream = null;
+                StreamReader reader = null;
                 if (!string.IsNullOrEmpty(contentEncoding) && contentEncoding.ToLower().Contains("gzip")) {
-                    stream = new GZipStream(stream, CompressionMode.Decompress);
+                    decompressedStream = new GZipStream(stream, CompressionMode.Decompress);
+                    reader = new StreamReader(decompressedStream);
                 }
-                var reader = new StreamReader(stream);
-                return reader.ReadToEnd();
+                else {
+                    reader = new StreamReader(stream);
+                }
+                var data =  reader.ReadToEnd();
+                reader.Close();
+                decompressedStream?.Close();
+                stream.Close();
+                return data;
             }
             
             public void SetProxy(String proxyURL)

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13709,21 +13709,16 @@ public interface DataDictionaryInterface
                 }
                 else {
                     // proxy support is disabled clear the proxy
-                    if (proxy != null) {
-                        proxy = null; 
-                        if (client != null) { 
-                            client.Proxy = null;
-                        }
-                    }
+                    proxy = null; 
                 }
                 if (client == null) {
                     client = new WebClient();
-                    client.Proxy = proxy;
                     String ua = "Mozilla/5.0 (compatible; PRoCon 1; Insane Limits)";
                     // XXX String ua = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; .NET CLR 3.5.30729)";
                     plugin.DebugWrite("Using user-agent: " + ua, 4);
                     client.Headers.Add("user-agent", ua);
                 }
+                client.Proxy = proxy;
                 
                 DateTime since = DateTime.Now;
 

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13683,7 +13683,7 @@ public interface DataDictionaryInterface
             private String ua;
             private bool compress;
 
-            public GZipWebClient(String ua = "Mozilla/5.0 (compatible; PRoCon 1; AdKats)", bool compress = true) {
+            public GZipWebClient(String ua = "Mozilla/5.0 (compatible; PRoCon 1; Insane Limits)", bool compress = true) {
                 this.ua = ua;
                 this.compress = compress;
                 base.Headers["User-Agent"] = ua;
@@ -13742,6 +13742,7 @@ public interface DataDictionaryInterface
         public void CleanUp()
         {
             client = null; // Release WebClient to avoid re-use error
+            curAddress = "";
         }
 
         private String fetchWebPage(ref String html_data, String url)
@@ -13761,7 +13762,7 @@ public interface DataDictionaryInterface
                     // set proxy
                     try {
                         var address = plugin.getStringVarValue("proxy_url");
-                        if (curAddress == null || !curAddress.Equals(address)) {
+                        if (curAddress == null || client.Proxy == null || !curAddress.Equals(address)) {
                             client.SetProxy(address); 
                             curAddress = address;
                         }

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Miguel Mendoza - miguel@micovery.com, PapaCharlie9, Singh400, EBastard
+ * Copyright 2011 Miguel Mendoza - miguel@micovery.com, PapaCharlie9, Singh400, EBastard, Hedius
  *
  * Insane Balancer is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the License,
@@ -3764,7 +3764,7 @@ namespace PRoConEvents
 
         public string GetPluginVersion()
         {
-            return "0.9.17.0";
+            return "0.9.18.0";
         }
 
         public string GetPluginAuthor()

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13680,12 +13680,18 @@ public interface DataDictionaryInterface
         WebProxy proxy = null;
         String curAddress = "";
         
-        public class GZipWebClient : WebClient 
-        {
+        public class GZipWebClient : WebClient {
+            private String ua;
+
+            public GZipWebClient(String ua = "Mozilla/5.0 (compatible; PRoCon 1; Insane Limits)") {
+                this.ua = ua;
+                base.Headers["User-Agent"] = ua;
+            }
             protected override WebRequest GetWebRequest(Uri address)
             {
                 HttpWebRequest request = (HttpWebRequest)base.GetWebRequest(address);
                 request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+                request.UserAgent = ua;
                 return request;
             }
         }
@@ -13726,11 +13732,10 @@ public interface DataDictionaryInterface
                     proxy = null; 
                 }
                 if (client == null) {
-                    client = new GZipWebClient();
                     String ua = "Mozilla/5.0 (compatible; PRoCon 1; Insane Limits)";
+                    client = new GZipWebClient(ua);
                     // XXX String ua = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; .NET CLR 3.5.30729)";
                     plugin.DebugWrite("Using user-agent: " + ua, 4);
-                    client.Headers["User-Agent"] = ua;
                 }
                 client.Proxy = proxy;
                 

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -30,7 +30,6 @@ using System.Reflection;
 using Microsoft.CSharp;
 using System.CodeDom;
 
-
 using PRoCon.Core;
 using PRoCon.Core.Plugin;
 using PRoCon.Core.Plugin.Commands;
@@ -13677,9 +13676,19 @@ public interface DataDictionaryInterface
         //private HttpWebRequest req = null;
         //private CookieContainer cookies = null;
 
-        WebClient client = null;
+        GZipWebClient client = null;
         WebProxy proxy = null;
         String curAddress = "";
+        
+        public class GZipWebClient : WebClient 
+        {
+            protected override WebRequest GetWebRequest(Uri address)
+            {
+                HttpWebRequest request = (HttpWebRequest)base.GetWebRequest(address);
+                request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+                return request;
+            }
+        }
 
         public BattleLog(InsaneLimits plugin)
         {
@@ -13717,7 +13726,7 @@ public interface DataDictionaryInterface
                     proxy = null; 
                 }
                 if (client == null) {
-                    client = new WebClient();
+                    client = new GZipWebClient();
                     String ua = "Mozilla/5.0 (compatible; PRoCon 1; Insane Limits)";
                     // XXX String ua = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; .NET CLR 3.5.30729)";
                     plugin.DebugWrite("Using user-agent: " + ua, 4);

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13730,7 +13730,7 @@ public interface DataDictionaryInterface
                     String ua = "Mozilla/5.0 (compatible; PRoCon 1; Insane Limits)";
                     // XXX String ua = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; .NET CLR 3.5.30729)";
                     plugin.DebugWrite("Using user-agent: " + ua, 4);
-                    client.Headers.Add("user-agent", ua);
+                    client.Headers["User-Agent"] = ua;
                 }
                 client.Proxy = proxy;
                 

--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -13679,6 +13679,7 @@ public interface DataDictionaryInterface
 
         WebClient client = null;
         WebProxy proxy = null;
+        String curAddress = "";
 
         public BattleLog(InsaneLimits plugin)
         {
@@ -13689,6 +13690,7 @@ public interface DataDictionaryInterface
         public void CleanUp()
         {
             client = null; // Release WebClient to avoid re-use error
+            proxy = null;
         }
 
 
@@ -13699,7 +13701,11 @@ public interface DataDictionaryInterface
                 // proxy support
                 if (plugin.getBooleanVarValue("use_battlelog_proxy")) {
                     // set proxy
-                    proxy = new WebProxy(plugin.getStringVarValue("proxy_url"), true);
+                    var address = plugin.getStringVarValue("proxy_url");
+                    if (proxy == null || !curAddress.Equals(address)) {
+                        proxy = new WebProxy(address, true);
+                        curAddress = address;
+                    }
                 }
                 else {
                     // proxy support is disabled clear the proxy

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
-See myrcon.com for plugin details:
+Fork with proxy support for bypassing rate limits.
 
+See myrcon.com for plugin details:
 https://forum.myrcon.com/showthread.php?5399


### PR DESCRIPTION
This pull request would do the following:
* Raise the version by 1
* Add two settings (Enable Proxy, Proxy URL) + Validation
* Add the proxy to all web requests. (fetchPage requests)

Reason:
Battlelog has been having a 20 requests / minute / per IP (or smth like that) since the last weekend. I bypass this limit by sending all requests to battlelog through a round robin proxy provider. Maybe this might be helpful for others?

Tested and working.